### PR TITLE
Deleted vendor and code refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+.phpunit.result.cache
+.idea/

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-{"version":1,"defects":[],"times":{"Remotion\\LambdaPhp\\Tests\\PHPRenderProgressTest::testClient":0.018,"Remotion\\LambdaPhp\\Tests\\PHPClientTest::testClient":0.028}}

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":[],"times":{"Remotion\\LambdaPhp\\Tests\\PHPRenderProgressTest::testClient":0.018,"Remotion\\LambdaPhp\\Tests\\PHPClientTest::testClient":0.028}}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "license": "proprietary",
   "autoload": {
     "psr-4": {
-      "Remotion\\LambdaPhp\\": "src/"
+      "Remotion\\LambdaPhp\\": "src/",
+      "Remotion\\LambdaPhp\\Tests\\": "tests/"
     }
   },
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.1"
+  },
+  "scripts": {
+    "test": "phpunit tests"
   }
 }

--- a/src/GetRenderProgressResponse.php
+++ b/src/GetRenderProgressResponse.php
@@ -4,7 +4,7 @@ namespace Remotion\LambdaPhp;
 
 class GetRenderProgressResponse
 {
-    public int $chunks;
+    public ?int $chunks;
     public bool $done;
     public float $overallProgress;
     public string $type;

--- a/src/PHPClient.php
+++ b/src/PHPClient.php
@@ -1,13 +1,9 @@
 <?php
 namespace Remotion\LambdaPhp;
 
-use Remotion\LambdaPhp\GetRenderProgressResponse;
-use Aws\Credentials\CredentialProvider;
 use Aws\Lambda\LambdaClient;
 use Exception;
 use stdClass;
-
-require_once __DIR__ . '/Version.php';
 
 class PHPClient
 {
@@ -62,7 +58,7 @@ class PHPClient
             'renderId' => $renderId,
             'bucketName' => $bucketName,
             'type' => 'status',
-            "version" => VERSION,
+            "version" => Semantic::VERSION,
             "s3OutputProvider" => null,
             "logLevel" => $logLevel ,
         );

--- a/src/PHPClient.php
+++ b/src/PHPClient.php
@@ -7,10 +7,10 @@ use stdClass;
 
 class PHPClient
 {
-    private $client;
-    private $region;
-    private $serveUrl;
-    private $functionName;
+    protected $client;
+    protected $region;
+    protected $serveUrl;
+    protected $functionName;
 
     public function __construct(string $region, string $serveUrl, string $functionName, ?callable $credential)
     {

--- a/src/RenderMediaOnLambdaResponse.php
+++ b/src/RenderMediaOnLambdaResponse.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Remotion\LambdaPhp;
+
+class RenderMediaOnLambdaResponse
+{
+    public string $type;
+    public string $bucketName;
+    public string $renderId;
+}

--- a/src/RenderParams.php
+++ b/src/RenderParams.php
@@ -856,7 +856,7 @@ class RenderParams
 
     public function setDeleteAfter($deleteAfter)
     {
-        $this->$deleteAfter = $deleteAfter;
+        $this->deleteAfter = $deleteAfter;
         return $this;
     }
 }

--- a/src/RenderParams.php
+++ b/src/RenderParams.php
@@ -6,52 +6,51 @@ use stdClass;
 
 class RenderParams
 {
+    protected $data = null;
+    protected $bucketName = null;
+    protected $region = null;
+    protected $outName = null;
+    protected $composition = null;
+    protected $serverUrl = null;
+    protected $framesPerLambda = null;
 
-    private $data = null;
-    private $bucketName = null;
-    private $region = null;
-    private $outName = null;
-    private $composition = null;
-    private $serverUrl = null;
-    private $framesPerLambda = null;
-
-    private $codec = 'h264';
-    private $version = "";
-    private $imageFormat = 'jpeg';
-    private $crf = null;
-    private $envVariables = [];
-    private $maxRetries = 1;
-    private $jpegQuality = 80;
-    private $privacy = 'private';
-    private $colorSpace = 'default';
-    private $logLevel = 'info';
-    private $frameRange = null;
-    private $timeoutInMilliseconds = 30000;
-    private $chromiumOptions = null;
-    private $scale = 1;
-    private $everyNthFrame = 1;
-    private $numberOfGifLoops = 0;
-    private $concurrencyPerLambda = 1;
-    private $downloadBehavior = [
+    protected $codec = 'h264';
+    protected $version = "";
+    protected $imageFormat = 'jpeg';
+    protected $crf = null;
+    protected $envVariables = [];
+    protected $maxRetries = 1;
+    protected $jpegQuality = 80;
+    protected $privacy = 'privacy';
+    protected $colorSpace = 'default';
+    protected $logLevel = 'info';
+    protected $frameRange = null;
+    protected $timeoutInMilliseconds = 30000;
+    protected $chromiumOptions = null;
+    protected $scale = 1;
+    protected $everyNthFrame = 1;
+    protected $numberOfGifLoops = 0;
+    protected $concurrencyPerLambda = 1;
+    protected $downloadBehavior = [
         'type' => 'play-in-browser',
     ];
-    private $muted = false;
-    private $preferLossless = false;
-    private $overwrite = false;
-    private $audioBitrate = null;
-    private $videoBitrate = null;
-    private $encodingBufferSize = null;
-    private $maxRate = null;
-    private $webhook = null;
-    private $forceHeight = null;
-    private $forceWidth = null;
-    private $offthreadVideoCacheSizeInBytes = null;
-    private $audioCodec = null;
-    private $rendererFunctionName = null;
-    private $proResProfile = null;
-    private $pixelFormat = null;
-    private $x264Preset = null;
-    private $deleteAfter = null;
+    protected $muted = false;
+    protected $preferLossless = false;
+    protected $overwrite = false;
+    protected $audioBitrate = null;
+    protected $videoBitrate = null;
+    protected $encodingBufferSize = null;
+    protected $maxRate = null;
+    protected $webhook = null;
+    protected $forceHeight = null;
+    protected $forceWidth = null;
+    protected $offthreadVideoCacheSizeInBytes = null;
+    protected $audioCodec = null;
+    protected $rendererFunctionName = null;
+    protected $proResProfile = null;
+    protected $pixelFormat = null;
+    protected $x264Preset = null;
+    protected $deleteAfter = null;
 
     public function __construct(
         ?array  $data = null,

--- a/src/RenderParams.php
+++ b/src/RenderParams.php
@@ -1,17 +1,8 @@
 <?php
+
 namespace Remotion\LambdaPhp;
 
-require_once __DIR__ . '/Version.php';
 use stdClass;
-use VERSION;
-
-class RenderMediaOnLambdaResponse
-{
-    public string $type;
-    public string $bucketName;
-    public string $renderId;
-}
-
 
 class RenderParams
 {
@@ -61,48 +52,48 @@ class RenderParams
     private $pixelFormat = null;
     private $x264Preset = null;
     private $deleteAfter = null;
-    
+
     public function __construct(
-        ?array $data = null,
+        ?array  $data = null,
         ?string $composition = 'main',
-        string $codec = 'h264',
+        string  $codec = 'h264',
         ?string $version = null,
-        string $imageFormat = 'jpeg',
-        ?int $crf = null,
-        ?array $envVariables = null,
-        int $maxRetries = 1,
-        int $jpegQuality = 80,
-        string $privacy = 'public',
-        string $colorSpace = 'default',
-        string $logLevel = 'info',
+        string  $imageFormat = 'jpeg',
+        ?int    $crf = null,
+        ?array  $envVariables = null,
+        int     $maxRetries = 1,
+        int     $jpegQuality = 80,
+        string  $privacy = 'public',
+        string  $colorSpace = 'default',
+        string  $logLevel = 'info',
         ?string $frameRange = null,
         ?string $outName = null,
-        ?int $timeoutInMilliseconds = 30000,
-        ?object $chromiumOptions = null, 
-        ?int $scale = 1, 
-        ?int $everyNthFrame = 1, 
-        ?int $numberOfGifLoops = 0, 
-        ?int $concurrencyPerLambda = 1, 
-        ?array $downloadBehavior = null, 
-        ?bool $muted = false, 
-        ?bool $overwrite = false, 
-        ?int $audioBitrate = null, 
-        ?int $videoBitrate = null, 
-        ?string $webhook = null, 
-        ?int $forceHeight = null, 
-        ?int $forceWidth = null, 
-        ?int $offthreadVideoCacheSizeInBytes = null, 
-        ?string $audioCodec = null, 
-        ?int $framesPerLambda = null, 
-        ?string $rendererFunctionName = null, 
-        ?string $proResProfile = null, 
+        ?int    $timeoutInMilliseconds = 30000,
+        ?object $chromiumOptions = null,
+        ?int    $scale = 1,
+        ?int    $everyNthFrame = 1,
+        ?int    $numberOfGifLoops = 0,
+        ?int    $concurrencyPerLambda = 1,
+        ?array  $downloadBehavior = null,
+        ?bool   $muted = false,
+        ?bool   $overwrite = false,
+        ?int    $audioBitrate = null,
+        ?int    $videoBitrate = null,
+        ?string $webhook = null,
+        ?int    $forceHeight = null,
+        ?int    $forceWidth = null,
+        ?int    $offthreadVideoCacheSizeInBytes = null,
+        ?string $audioCodec = null,
+        ?int    $framesPerLambda = null,
+        ?string $rendererFunctionName = null,
+        ?string $proResProfile = null,
         ?string $pixelFormat = null,
         ?string $x264Preset = null,
         ?string $deleteAfter = null,
         ?string $encodingBufferSize = null,
         ?string $maxRate = null,
-        ?bool $preferLossless = false 
-        )
+        ?bool   $preferLossless = false
+    )
     {
         if ($chromiumOptions === null) {
             $this->chromiumOptions = new stdClass();
@@ -150,6 +141,7 @@ class RenderParams
     }
 
     private array $inputProps = array();
+
     public function serializeParams()
     {
         $parameters = [
@@ -176,7 +168,7 @@ class RenderParams
             'downloadBehavior' => $this->getDownloadBehavior(),
             'muted' => $this->getMuted(),
             'preferLossless' => $this->getPreferLossless(),
-            'version' => VERSION,
+            'version' => Semantic::VERSION,
             'overwrite' => $this->getOverwrite(),
             'audioBitrate' => $this->getAudioBitrate(),
             'videoBitrate' => $this->getVideoBitrate(),
@@ -451,7 +443,7 @@ class RenderParams
         return $this;
     }
 
-      /**
+    /**
      * Get the value of jpegQuality
      */
     public function getJpegQuality()
@@ -491,7 +483,7 @@ class RenderParams
         return $this;
     }
 
-        /**
+    /**
      * Get the value of colorspace
      */
     public function getColorSpace()
@@ -530,6 +522,7 @@ class RenderParams
 
         return $this;
     }
+
     // Setter methods
     public function setFrameRange($frameRange)
     {
@@ -627,6 +620,7 @@ class RenderParams
     {
         $this->muted = $muted;
     }
+
     // Setter methods
     public function setPreferLossless($preferLossless)
     {
@@ -718,6 +712,7 @@ class RenderParams
     {
         return $this->forceWidth;
     }
+
     public function getOffthreadVideoCacheSizeInBytes()
     {
         return $this->offthreadVideoCacheSizeInBytes;
@@ -850,8 +845,8 @@ class RenderParams
 
     public function setX264Preset($x264Preset)
     {
-         $this->x264Preset = $x264Preset;
-         return $this;
+        $this->x264Preset = $x264Preset;
+        return $this;
     }
 
     public function getDeleteAfter()
@@ -861,7 +856,7 @@ class RenderParams
 
     public function setDeleteAfter($deleteAfter)
     {
-         $this->$deleteAfter = $deleteAfter;
-         return $this;
+        $this->$deleteAfter = $deleteAfter;
+        return $this;
     }
 }

--- a/src/Semantic.php
+++ b/src/Semantic.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Remotion\LambdaPhp;
+
+class Semantic
+{
+    public const VERSION = "4.0.145";
+}

--- a/src/ValidationException.php
+++ b/src/ValidationException.php
@@ -5,4 +5,6 @@ namespace Remotion\LambdaPhp;
 use Exception;
 
 class ValidationException extends Exception
-{}
+{
+    // Do Nothing
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,4 +1,0 @@
-<?php 
-namespace Remotion\LambdaPhp;
-
-const VERSION = "4.0.145";

--- a/tests/PHPClientTest.php
+++ b/tests/PHPClientTest.php
@@ -1,8 +1,6 @@
 <?php
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
-require_once __DIR__ . '/PHPClient.php';
-require_once __DIR__ . '/RenderParams.php';
+namespace Remotion\LambdaPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Remotion\LambdaPhp\PHPClient;

--- a/tests/PHPRenderProgressTest.php
+++ b/tests/PHPRenderProgressTest.php
@@ -1,12 +1,9 @@
 <?php
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
-require_once __DIR__ . '/PHPClient.php';
-require_once __DIR__ . '/RenderParams.php';
+namespace Remotion\LambdaPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Remotion\LambdaPhp\PHPClient;
-use Remotion\LambdaPhp\RenderParams;
 
 class PHPRenderProgressTest extends TestCase
 {


### PR DESCRIPTION
- Using the standards of composer for organising code and also seperation of tests from `/src` directory
- Refactored code based on PSR-12 standard